### PR TITLE
python3 compatibility

### DIFF
--- a/build_vhdl_packages
+++ b/build_vhdl_packages
@@ -30,7 +30,7 @@ import math
 import uhal
 from tree import * # import node,arraynode,tree
 
-import StringIO
+import io
 
 #===========================================================================================
 # In Python 3 "xrange" doesn't exist, since Python 3's "range" is just as efficient as Python 2's "xrange"

--- a/node.py
+++ b/node.py
@@ -8,7 +8,7 @@ import logging
 import math
 import uhal
 
-import StringIO
+import io
 EXIT_CODE_INCORRECT_ARGUMENTS = 1
 EXIT_CODE_ARG_PARSING_ERROR   = 2
 EXIT_CODE_NODE_ADDRESS_ERRORS = 3

--- a/tree.py
+++ b/tree.py
@@ -86,11 +86,11 @@ class tree(object):
                 package_description[child.id] = ""
                 array_postfix = ["","_ARRAY"][child.isArray()]
                 ##### make the records for package entries
-                if child_records.has_key('mon'):
+                if 'mon' in child_records:
                     package_mon_entries[child.id] = child.getPath(expandArray=False).replace('.','_')+'_MON_t'+array_postfix
-                if child_records.has_key('ctrl'):
+                if 'ctrl' in child_records:
                     package_ctrl_entries[child.id] = child.getPath(expandArray=False).replace('.','_') + '_CTRL_t'+array_postfix
-                if child_records.has_key('ctrl_default'):
+                if 'ctrl_default' in child_records:
                     default_package_entries = "DEFAULT_"+child.getPath(expandArray=False).replace('.','_')+"_CTRL_t"
                     if child.isArray(): default_package_entries = "(others => "+default_package_entries+" )"
                     package_ctrl_entry_defaults[child.id] = default_package_entries
@@ -111,7 +111,7 @@ class tree(object):
                 elif child.permission == 'rw':
                     package_ctrl_entries[child.id] = package_entries
                     ##### store data for default signal
-                    if child.parameters.has_key("default"):
+                    if "default" in child.parameters:
                         intValue = int(child.parameters["default"],0)
                         if bits.find("downto") > 0:
                             if bitCount % 4 == 0:
@@ -126,7 +126,7 @@ class tree(object):
                         package_ctrl_entry_defaults[child.id] = "'0'"
                 elif child.permission == 'w':
                     ##### store data for default signal
-                    if child.parameters.has_key("default"):
+                    if "default" in child.parameters:
                         print("Action register with default value!\n")
                     elif bits.find("downto") > 0:
                         package_ctrl_entry_defaults[child.id] = "(others => '0')"
@@ -175,7 +175,7 @@ class tree(object):
             return assignmentPos
         numberStart = line[0:assignmentPos].rfind("(")+1
         numberEnd = line[numberStart:assignmentPos].find("downto");
-        if numberEnd < 0:        
+        if numberEnd < 0:
             numberEnd = line[numberStart:assignmentPos].find(")");
         if numberEnd < 0:
             return 0
@@ -184,7 +184,7 @@ class tree(object):
 
     @staticmethod
     def generateAlignedCase(operations):
-        output = StringIO.StringIO()
+        output = io.StringIO()
         newAssignmentPos = 0
         newAssignmentLength = 0
         for addr in operations:
@@ -221,7 +221,7 @@ class tree(object):
         return self.generateAlignedCase(self.write_ops)
 
     def generate_rw_ops_output(self):
-        output = StringIO.StringIO()
+        output = io.StringIO()
         newAssignmentPos = 0
         newAssignmentLength = 0
         for line in self.readwrite_ops.split("\n"):
@@ -247,13 +247,13 @@ class tree(object):
         return output.getvalue()
 
     def generate_a_ops_output(self):
-        output = StringIO.StringIO()
+        output = io.StringIO()
         for line in self.action_ops.split("\n"):
             output.write("      "+line+"\n")
         return output.getvalue()
 
     def generate_def_ops_output(self):
-        output = StringIO.StringIO()
+        output = io.StringIO()
         for line in self.default_ops.split("\n"):
             if(len(line)):
                 output.write("      "+line.split("<")[0])
@@ -279,23 +279,23 @@ class tree(object):
             else:
                 bits = child.getBitRange()
                 if child.permission == 'r':
-                    if self.read_ops.has_key(child.getLocalAddress()):
+                    if child.getLocalAddress() in self.read_ops:
                         self.read_ops[child.getLocalAddress()] = self.read_ops[child.getLocalAddress()] + str("localRdData("+bits+")")+" <= Mon."+child.getPath(includeRoot=False,expandArray=True)+"; --"+child.description+"\n"
                     else:
                         self.read_ops[child.getLocalAddress()] = str("localRdData("+bits+")")+" <= Mon."+child.getPath(includeRoot=False,expandArray=True)+"; --"+child.description+"\n"
                 elif child.permission == 'rw':
-                    if self.read_ops.has_key(child.getLocalAddress()):
+                    if child.getLocalAddress()  in self.read_ops:
                         self.read_ops[child.getLocalAddress()] = self.read_ops[child.getLocalAddress()] + str("localRdData("+bits+")")+" <= "+"reg_data("+str(child.getLocalAddress()).rjust(2)+")("+bits+"); --"+child.description+"\n"
                     else:
                         self.read_ops[child.getLocalAddress()] = str("localRdData("+bits+")")+" <= "+"reg_data("+str(child.getLocalAddress()).rjust(2)+")("+bits+"); --"+child.description+"\n"
-                    if self.write_ops.has_key(child.getLocalAddress()):
+                    if child.getLocalAddress() in self.write_ops:
                         self.write_ops[child.getLocalAddress()] = self.write_ops[child.getLocalAddress()] + str("reg_data("+str(child.getLocalAddress()).rjust(2)+")("+bits+")") + " <= localWrData("+bits+"); --"+child.description+"\n"
                     else:
                         self.write_ops[child.getLocalAddress()] = str("reg_data("+str(child.getLocalAddress()).rjust(2)+")("+bits+")") + " <= localWrData("+bits+"); --"+child.description+"\n"
                     self.readwrite_ops+=("Ctrl."+child.getPath(includeRoot=False,expandArray=True)) + " <= reg_data("+str(child.getLocalAddress()).rjust(2)+")("+bits+");\n"
                     self.default_ops+="reg_data("+str(child.getLocalAddress()).rjust(2)+")("+bits+") <= "+("CTRL_t."+child.getPath(includeRoot=False,expandArray=True))+";\n"
                 elif child.permission == 'w':
-                    if self.write_ops.has_key(child.getLocalAddress()):
+                    if child.getLocalAddress() in self.write_ops:
                         self.write_ops[child.getLocalAddress()] = self.write_ops[child.getLocalAddress()] + ("Ctrl."+child.getPath(includeRoot=False)) + " <= localWrData("+bits+");\n"
                     else:                                                     
                         self.write_ops[child.getLocalAddress()] = ("Ctrl."+child.getPath(includeRoot=False,expandArray=True)) + " <= localWrData("+bits+");\n"

--- a/tree.py
+++ b/tree.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from node import *
 from jinja2 import Template
 
@@ -102,7 +103,7 @@ class tree(object):
                 if bitCount == 1:
                     package_entries += "std_logic"
                 else:
-                    package_entries += "std_logic_vector(" + str(bitCount-1).rjust(2,' ') + " downto 0)"
+                    package_entries += "std_logic_vector(" + str(bitCount-1).rjust(2,str(' ')) + " downto 0)"
                 
                 package_description[child.id] = child.description
                 bits = child.getBitRange()


### PR DESCRIPTION
I installed IPBus on my computer but it used the default python installation, which for me was python3..

Running these scripts then does not work with python2 but some minor modifications seem to make it compatible for both python2 and python3, assuming a remotely modern python2 (I think 2.6).

Specifically: 

1. ```import StringIO``` replaced with ```import io``` 
1. ```if dict.has_key('key')``` replaced with ```if key in dict``` 

I tested both on my computer and on Tesla (which I assume is using python2 by default) and it seems to work ok.. would someone else be able to check this and see if it works ok for them?