### PR TITLE
makefile path changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+#################################################################################
+# Generate MAP and PKG files from address table
+#################################################################################
+export LD_LIBRARY_PATH=/opt/cactus/lib
+XML2VHD_PATH=$(shell pwd)
+SYM_LNK_XMLS=$(shell find ../ -type l -name "*.xml")
+include xml_regmap.mk
+.DEFAULT_GOAL := xml_regmap
+clean: clean_regmap

--- a/xml_regmap.mk
+++ b/xml_regmap.mk
@@ -5,7 +5,7 @@ export LD_LIBRARY_PATH=/opt/cactus/lib
 SRC_PATH=src
 XML2VHD_PATH?=xml_regmap
 
-SYM_LNK_XMLS = $(shell find ./src -type l)
+SYM_LNK_XMLS ?= $(shell find ./src -type l)
 MAP_OBJS = $(patsubst %.xml, %_map.vhd, $(SYM_LNK_XMLS))
 PKG_OBJS = $(patsubst %.xml, %_PKG.vhd, $(SYM_LNK_XMLS))
 
@@ -19,7 +19,7 @@ xml_regmap : $(MAP_OBJS)
 
 %_map.vhd %_PKG.vhd : %.xml
 	@cd $(dir $<) &&\
-	../../$(XML2VHD_PATH)/generate_test_xml $(basename $(notdir $<)) &&\
-	../../$(XML2VHD_PATH)/build_vhdl_packages test.xml &&\
+	$(XML2VHD_PATH)/generate_test_xml $(basename $(notdir $<)) &&\
+	$(XML2VHD_PATH)/build_vhdl_packages test.xml &&\
 	rm test.xml
 


### PR DESCRIPTION
Addresses issues noted in issue #4 

Note that using this requires changing the main firmware makefile to pass the absolute path to the regmap tool, e.g.
```
XML2VHD_PATH=$(shell pwd)/regmap_helper
```
instead of 
```
XML2VHD_PATH=regmap_helper
```