### PR TITLE
Add a CI job to check generated products

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,14 @@
+name: test-regmap
+on: [push]
+jobs:
+  test_parser:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-python@v3
+        with:
+          python-version: '3.8'
+      - name: "Test regmap"
+        run: |
+              pip install lxml jinja2
+              make -C tester test_simple_parser

--- a/tester/CParserTest/CM_USP_map.vhd
+++ b/tester/CParserTest/CM_USP_map.vhd
@@ -10,9 +10,12 @@ use work.types.all;
 
 use work.CM_USP_Ctrl.all;
 
+
+
 entity CM_USP_map is
   generic (
-    READ_TIMEOUT     : integer := 2048
+    READ_TIMEOUT     : integer := 2048;
+    ALLOCATED_MEMORY_RANGE : integer
     );
   port (
     clk_axi          : in  std_logic;
@@ -47,6 +50,13 @@ begin  -- architecture behavioral
   -- AXI 
   -------------------------------------------------------------------------------
   -------------------------------------------------------------------------------
+  assert ((4*346) <= ALLOCATED_MEMORY_RANGE)
+    report "CM_USP: Regmap addressing range " & integer'image(4*346) & " is outside of AXI mapped range " & integer'image(ALLOCATED_MEMORY_RANGE)
+  severity ERROR;
+  assert ((4*346) > ALLOCATED_MEMORY_RANGE)
+    report "CM_USP: Regmap addressing range " & integer'image(4*346) & " is inside of AXI mapped range " & integer'image(ALLOCATED_MEMORY_RANGE)
+  severity NOTE;
+
   AXIRegBridge : entity work.axiLiteRegBlocking
     generic map (
       READ_TIMEOUT => READ_TIMEOUT
@@ -646,6 +656,7 @@ begin  -- architecture behavioral
       reg_data(25)(31 downto 27)  <= DEFAULT_CM_USP_CTRL_t.CM(1).C2C(1).LINK_DEBUG.TX.PRE_CURSOR;
       reg_data(26)( 3 downto  0)  <= DEFAULT_CM_USP_CTRL_t.CM(1).C2C(1).LINK_DEBUG.TX.PRBS_SEL;
       reg_data(26)( 8 downto  4)  <= DEFAULT_CM_USP_CTRL_t.CM(1).C2C(1).LINK_DEBUG.TX.DIFF_CTRL;
+      reg_data(40)( 0)  <= DEFAULT_CM_USP_CTRL_t.CM(1).C2C(1).CNT.RESET_COUNTERS;
       reg_data(48)(11)  <= DEFAULT_CM_USP_CTRL_t.CM(1).C2C(2).ENABLE_PHY_CTRL;
       reg_data(49)(31 downto  0)  <= DEFAULT_CM_USP_CTRL_t.CM(1).C2C(2).PHY_LANE_STABLE;
       reg_data(50)(23 downto  0)  <= DEFAULT_CM_USP_CTRL_t.CM(1).C2C(2).PHY_READ_TIME;
@@ -671,6 +682,7 @@ begin  -- architecture behavioral
       reg_data(57)(31 downto 27)  <= DEFAULT_CM_USP_CTRL_t.CM(1).C2C(2).LINK_DEBUG.TX.PRE_CURSOR;
       reg_data(58)( 3 downto  0)  <= DEFAULT_CM_USP_CTRL_t.CM(1).C2C(2).LINK_DEBUG.TX.PRBS_SEL;
       reg_data(58)( 8 downto  4)  <= DEFAULT_CM_USP_CTRL_t.CM(1).C2C(2).LINK_DEBUG.TX.DIFF_CTRL;
+      reg_data(72)( 0)  <= DEFAULT_CM_USP_CTRL_t.CM(1).C2C(2).CNT.RESET_COUNTERS;
       reg_data(80)( 7 downto  0)  <= DEFAULT_CM_USP_CTRL_t.CM(1).MONITOR.COUNT_16X_BAUD;
       reg_data(84)( 0)  <= DEFAULT_CM_USP_CTRL_t.CM(1).MONITOR.ERRORS.RESET;
       reg_data(90)(31 downto  0)  <= DEFAULT_CM_USP_CTRL_t.CM(1).MONITOR.SM_TIMEOUT;
@@ -703,6 +715,7 @@ begin  -- architecture behavioral
       reg_data(281)(31 downto 27)  <= DEFAULT_CM_USP_CTRL_t.CM(2).C2C(1).LINK_DEBUG.TX.PRE_CURSOR;
       reg_data(282)( 3 downto  0)  <= DEFAULT_CM_USP_CTRL_t.CM(2).C2C(1).LINK_DEBUG.TX.PRBS_SEL;
       reg_data(282)( 8 downto  4)  <= DEFAULT_CM_USP_CTRL_t.CM(2).C2C(1).LINK_DEBUG.TX.DIFF_CTRL;
+      reg_data(296)( 0)  <= DEFAULT_CM_USP_CTRL_t.CM(2).C2C(1).CNT.RESET_COUNTERS;
       reg_data(304)(11)  <= DEFAULT_CM_USP_CTRL_t.CM(2).C2C(2).ENABLE_PHY_CTRL;
       reg_data(305)(31 downto  0)  <= DEFAULT_CM_USP_CTRL_t.CM(2).C2C(2).PHY_LANE_STABLE;
       reg_data(306)(23 downto  0)  <= DEFAULT_CM_USP_CTRL_t.CM(2).C2C(2).PHY_READ_TIME;
@@ -728,6 +741,7 @@ begin  -- architecture behavioral
       reg_data(313)(31 downto 27)  <= DEFAULT_CM_USP_CTRL_t.CM(2).C2C(2).LINK_DEBUG.TX.PRE_CURSOR;
       reg_data(314)( 3 downto  0)  <= DEFAULT_CM_USP_CTRL_t.CM(2).C2C(2).LINK_DEBUG.TX.PRBS_SEL;
       reg_data(314)( 8 downto  4)  <= DEFAULT_CM_USP_CTRL_t.CM(2).C2C(2).LINK_DEBUG.TX.DIFF_CTRL;
+      reg_data(328)( 0)  <= DEFAULT_CM_USP_CTRL_t.CM(2).C2C(2).CNT.RESET_COUNTERS;
       reg_data(336)( 7 downto  0)  <= DEFAULT_CM_USP_CTRL_t.CM(2).MONITOR.COUNT_16X_BAUD;
       reg_data(340)( 0)  <= DEFAULT_CM_USP_CTRL_t.CM(2).MONITOR.ERRORS.RESET;
       reg_data(346)(31 downto  0)  <= DEFAULT_CM_USP_CTRL_t.CM(2).MONITOR.SM_TIMEOUT;

--- a/tester/CParserTest/MEM_TEST_map.vhd
+++ b/tester/CParserTest/MEM_TEST_map.vhd
@@ -10,9 +10,12 @@ use work.types.all;
 use work.BRAMPortPkg.all;
 use work.MEM_TEST_Ctrl.all;
 
+
+
 entity MEM_TEST_map is
   generic (
-    READ_TIMEOUT     : integer := 2048
+    READ_TIMEOUT     : integer := 2048;
+    ALLOCATED_MEMORY_RANGE : integer
     );
   port (
     clk_axi          : in  std_logic;
@@ -57,6 +60,13 @@ begin  -- architecture behavioral
   -- AXI 
   -------------------------------------------------------------------------------
   -------------------------------------------------------------------------------
+  assert ((4*1280) <= ALLOCATED_MEMORY_RANGE)
+    report "MEM_TEST: Regmap addressing range " & integer'image(4*1280) & " is outside of AXI mapped range " & integer'image(ALLOCATED_MEMORY_RANGE)
+  severity ERROR;
+  assert ((4*1280) > ALLOCATED_MEMORY_RANGE)
+    report "MEM_TEST: Regmap addressing range " & integer'image(4*1280) & " is inside of AXI mapped range " & integer'image(ALLOCATED_MEMORY_RANGE)
+  severity NOTE;
+
   AXIRegBridge : entity work.axiLiteRegBlocking
     generic map (
       READ_TIMEOUT => READ_TIMEOUT

--- a/tester/CParserTest_wishbone/CM_USP_map.vhd
+++ b/tester/CParserTest_wishbone/CM_USP_map.vhd
@@ -794,6 +794,7 @@ begin  -- architecture behavioral
       reg_data(25)(31 downto 27)  <= DEFAULT_CM_USP_CTRL_t.CM(1).C2C(1).LINK_DEBUG.TX.PRE_CURSOR;
       reg_data(26)( 3 downto  0)  <= DEFAULT_CM_USP_CTRL_t.CM(1).C2C(1).LINK_DEBUG.TX.PRBS_SEL;
       reg_data(26)( 8 downto  4)  <= DEFAULT_CM_USP_CTRL_t.CM(1).C2C(1).LINK_DEBUG.TX.DIFF_CTRL;
+      reg_data(40)( 0)  <= DEFAULT_CM_USP_CTRL_t.CM(1).C2C(1).CNT.RESET_COUNTERS;
       reg_data(48)(11)  <= DEFAULT_CM_USP_CTRL_t.CM(1).C2C(2).ENABLE_PHY_CTRL;
       reg_data(49)(31 downto  0)  <= DEFAULT_CM_USP_CTRL_t.CM(1).C2C(2).PHY_LANE_STABLE;
       reg_data(50)(23 downto  0)  <= DEFAULT_CM_USP_CTRL_t.CM(1).C2C(2).PHY_READ_TIME;
@@ -819,6 +820,7 @@ begin  -- architecture behavioral
       reg_data(57)(31 downto 27)  <= DEFAULT_CM_USP_CTRL_t.CM(1).C2C(2).LINK_DEBUG.TX.PRE_CURSOR;
       reg_data(58)( 3 downto  0)  <= DEFAULT_CM_USP_CTRL_t.CM(1).C2C(2).LINK_DEBUG.TX.PRBS_SEL;
       reg_data(58)( 8 downto  4)  <= DEFAULT_CM_USP_CTRL_t.CM(1).C2C(2).LINK_DEBUG.TX.DIFF_CTRL;
+      reg_data(72)( 0)  <= DEFAULT_CM_USP_CTRL_t.CM(1).C2C(2).CNT.RESET_COUNTERS;
       reg_data(80)( 7 downto  0)  <= DEFAULT_CM_USP_CTRL_t.CM(1).MONITOR.COUNT_16X_BAUD;
       reg_data(84)( 0)  <= DEFAULT_CM_USP_CTRL_t.CM(1).MONITOR.ERRORS.RESET;
       reg_data(90)(31 downto  0)  <= DEFAULT_CM_USP_CTRL_t.CM(1).MONITOR.SM_TIMEOUT;
@@ -851,6 +853,7 @@ begin  -- architecture behavioral
       reg_data(281)(31 downto 27)  <= DEFAULT_CM_USP_CTRL_t.CM(2).C2C(1).LINK_DEBUG.TX.PRE_CURSOR;
       reg_data(282)( 3 downto  0)  <= DEFAULT_CM_USP_CTRL_t.CM(2).C2C(1).LINK_DEBUG.TX.PRBS_SEL;
       reg_data(282)( 8 downto  4)  <= DEFAULT_CM_USP_CTRL_t.CM(2).C2C(1).LINK_DEBUG.TX.DIFF_CTRL;
+      reg_data(296)( 0)  <= DEFAULT_CM_USP_CTRL_t.CM(2).C2C(1).CNT.RESET_COUNTERS;
       reg_data(304)(11)  <= DEFAULT_CM_USP_CTRL_t.CM(2).C2C(2).ENABLE_PHY_CTRL;
       reg_data(305)(31 downto  0)  <= DEFAULT_CM_USP_CTRL_t.CM(2).C2C(2).PHY_LANE_STABLE;
       reg_data(306)(23 downto  0)  <= DEFAULT_CM_USP_CTRL_t.CM(2).C2C(2).PHY_READ_TIME;
@@ -876,6 +879,7 @@ begin  -- architecture behavioral
       reg_data(313)(31 downto 27)  <= DEFAULT_CM_USP_CTRL_t.CM(2).C2C(2).LINK_DEBUG.TX.PRE_CURSOR;
       reg_data(314)( 3 downto  0)  <= DEFAULT_CM_USP_CTRL_t.CM(2).C2C(2).LINK_DEBUG.TX.PRBS_SEL;
       reg_data(314)( 8 downto  4)  <= DEFAULT_CM_USP_CTRL_t.CM(2).C2C(2).LINK_DEBUG.TX.DIFF_CTRL;
+      reg_data(328)( 0)  <= DEFAULT_CM_USP_CTRL_t.CM(2).C2C(2).CNT.RESET_COUNTERS;
       reg_data(336)( 7 downto  0)  <= DEFAULT_CM_USP_CTRL_t.CM(2).MONITOR.COUNT_16X_BAUD;
       reg_data(340)( 0)  <= DEFAULT_CM_USP_CTRL_t.CM(2).MONITOR.ERRORS.RESET;
       reg_data(346)(31 downto  0)  <= DEFAULT_CM_USP_CTRL_t.CM(2).MONITOR.SM_TIMEOUT;

--- a/tester/Makefile
+++ b/tester/Makefile
@@ -1,6 +1,17 @@
-test: clean
+test: clean_simple clean_uhal
 	python generate_test_xml.py
 	python test_vhdl_packages.py
 
-clean:
-	rm -rf CParserTest UParserTest CParserTest_wishbone UParserTest_wishbone
+test_simple_parser:  clean_simple
+	python generate_test_xml.py
+	python test_vhdl_packages.py simple
+
+test_uhal_parser:  clean_uhal
+	python generate_test_xml.py
+	python test_vhdl_packages.py uhal
+
+clean_simple:
+	rm -rf CParserTest  CParserTest_wishbone
+
+clean_uhal:
+	rm -rf UParserTest UParserTest_wishbone

--- a/tester/UParserTest/CM_USP_map.vhd
+++ b/tester/UParserTest/CM_USP_map.vhd
@@ -10,9 +10,12 @@ use work.types.all;
 
 use work.CM_USP_Ctrl.all;
 
+
+
 entity CM_USP_map is
   generic (
-    READ_TIMEOUT     : integer := 2048
+    READ_TIMEOUT     : integer := 2048;
+    ALLOCATED_MEMORY_RANGE : integer
     );
   port (
     clk_axi          : in  std_logic;
@@ -47,6 +50,13 @@ begin  -- architecture behavioral
   -- AXI 
   -------------------------------------------------------------------------------
   -------------------------------------------------------------------------------
+  assert ((4*346) <= ALLOCATED_MEMORY_RANGE)
+    report "CM_USP: Regmap addressing range " & integer'image(4*346) & " is outside of AXI mapped range " & integer'image(ALLOCATED_MEMORY_RANGE)
+  severity ERROR;
+  assert ((4*346) > ALLOCATED_MEMORY_RANGE)
+    report "CM_USP: Regmap addressing range " & integer'image(4*346) & " is inside of AXI mapped range " & integer'image(ALLOCATED_MEMORY_RANGE)
+  severity NOTE;
+
   AXIRegBridge : entity work.axiLiteRegBlocking
     generic map (
       READ_TIMEOUT => READ_TIMEOUT
@@ -646,6 +656,7 @@ begin  -- architecture behavioral
       reg_data(25)(31 downto 27)  <= DEFAULT_CM_USP_CTRL_t.CM(1).C2C(1).LINK_DEBUG.TX.PRE_CURSOR;
       reg_data(26)( 3 downto  0)  <= DEFAULT_CM_USP_CTRL_t.CM(1).C2C(1).LINK_DEBUG.TX.PRBS_SEL;
       reg_data(26)( 8 downto  4)  <= DEFAULT_CM_USP_CTRL_t.CM(1).C2C(1).LINK_DEBUG.TX.DIFF_CTRL;
+      reg_data(40)( 0)  <= DEFAULT_CM_USP_CTRL_t.CM(1).C2C(1).CNT.RESET_COUNTERS;
       reg_data(48)(11)  <= DEFAULT_CM_USP_CTRL_t.CM(1).C2C(2).ENABLE_PHY_CTRL;
       reg_data(49)(31 downto  0)  <= DEFAULT_CM_USP_CTRL_t.CM(1).C2C(2).PHY_LANE_STABLE;
       reg_data(50)(23 downto  0)  <= DEFAULT_CM_USP_CTRL_t.CM(1).C2C(2).PHY_READ_TIME;
@@ -671,6 +682,7 @@ begin  -- architecture behavioral
       reg_data(57)(31 downto 27)  <= DEFAULT_CM_USP_CTRL_t.CM(1).C2C(2).LINK_DEBUG.TX.PRE_CURSOR;
       reg_data(58)( 3 downto  0)  <= DEFAULT_CM_USP_CTRL_t.CM(1).C2C(2).LINK_DEBUG.TX.PRBS_SEL;
       reg_data(58)( 8 downto  4)  <= DEFAULT_CM_USP_CTRL_t.CM(1).C2C(2).LINK_DEBUG.TX.DIFF_CTRL;
+      reg_data(72)( 0)  <= DEFAULT_CM_USP_CTRL_t.CM(1).C2C(2).CNT.RESET_COUNTERS;
       reg_data(80)( 7 downto  0)  <= DEFAULT_CM_USP_CTRL_t.CM(1).MONITOR.COUNT_16X_BAUD;
       reg_data(84)( 0)  <= DEFAULT_CM_USP_CTRL_t.CM(1).MONITOR.ERRORS.RESET;
       reg_data(90)(31 downto  0)  <= DEFAULT_CM_USP_CTRL_t.CM(1).MONITOR.SM_TIMEOUT;
@@ -703,6 +715,7 @@ begin  -- architecture behavioral
       reg_data(281)(31 downto 27)  <= DEFAULT_CM_USP_CTRL_t.CM(2).C2C(1).LINK_DEBUG.TX.PRE_CURSOR;
       reg_data(282)( 3 downto  0)  <= DEFAULT_CM_USP_CTRL_t.CM(2).C2C(1).LINK_DEBUG.TX.PRBS_SEL;
       reg_data(282)( 8 downto  4)  <= DEFAULT_CM_USP_CTRL_t.CM(2).C2C(1).LINK_DEBUG.TX.DIFF_CTRL;
+      reg_data(296)( 0)  <= DEFAULT_CM_USP_CTRL_t.CM(2).C2C(1).CNT.RESET_COUNTERS;
       reg_data(304)(11)  <= DEFAULT_CM_USP_CTRL_t.CM(2).C2C(2).ENABLE_PHY_CTRL;
       reg_data(305)(31 downto  0)  <= DEFAULT_CM_USP_CTRL_t.CM(2).C2C(2).PHY_LANE_STABLE;
       reg_data(306)(23 downto  0)  <= DEFAULT_CM_USP_CTRL_t.CM(2).C2C(2).PHY_READ_TIME;
@@ -728,6 +741,7 @@ begin  -- architecture behavioral
       reg_data(313)(31 downto 27)  <= DEFAULT_CM_USP_CTRL_t.CM(2).C2C(2).LINK_DEBUG.TX.PRE_CURSOR;
       reg_data(314)( 3 downto  0)  <= DEFAULT_CM_USP_CTRL_t.CM(2).C2C(2).LINK_DEBUG.TX.PRBS_SEL;
       reg_data(314)( 8 downto  4)  <= DEFAULT_CM_USP_CTRL_t.CM(2).C2C(2).LINK_DEBUG.TX.DIFF_CTRL;
+      reg_data(328)( 0)  <= DEFAULT_CM_USP_CTRL_t.CM(2).C2C(2).CNT.RESET_COUNTERS;
       reg_data(336)( 7 downto  0)  <= DEFAULT_CM_USP_CTRL_t.CM(2).MONITOR.COUNT_16X_BAUD;
       reg_data(340)( 0)  <= DEFAULT_CM_USP_CTRL_t.CM(2).MONITOR.ERRORS.RESET;
       reg_data(346)(31 downto  0)  <= DEFAULT_CM_USP_CTRL_t.CM(2).MONITOR.SM_TIMEOUT;

--- a/tester/UParserTest/MEM_TEST_map.vhd
+++ b/tester/UParserTest/MEM_TEST_map.vhd
@@ -10,9 +10,12 @@ use work.types.all;
 use work.BRAMPortPkg.all;
 use work.MEM_TEST_Ctrl.all;
 
+
+
 entity MEM_TEST_map is
   generic (
-    READ_TIMEOUT     : integer := 2048
+    READ_TIMEOUT     : integer := 2048;
+    ALLOCATED_MEMORY_RANGE : integer
     );
   port (
     clk_axi          : in  std_logic;
@@ -57,6 +60,13 @@ begin  -- architecture behavioral
   -- AXI 
   -------------------------------------------------------------------------------
   -------------------------------------------------------------------------------
+  assert ((4*1280) <= ALLOCATED_MEMORY_RANGE)
+    report "MEM_TEST: Regmap addressing range " & integer'image(4*1280) & " is outside of AXI mapped range " & integer'image(ALLOCATED_MEMORY_RANGE)
+  severity ERROR;
+  assert ((4*1280) > ALLOCATED_MEMORY_RANGE)
+    report "MEM_TEST: Regmap addressing range " & integer'image(4*1280) & " is inside of AXI mapped range " & integer'image(ALLOCATED_MEMORY_RANGE)
+  severity NOTE;
+
   AXIRegBridge : entity work.axiLiteRegBlocking
     generic map (
       READ_TIMEOUT => READ_TIMEOUT

--- a/tester/UParserTest_wishbone/CM_USP_map.vhd
+++ b/tester/UParserTest_wishbone/CM_USP_map.vhd
@@ -794,6 +794,7 @@ begin  -- architecture behavioral
       reg_data(25)(31 downto 27)  <= DEFAULT_CM_USP_CTRL_t.CM(1).C2C(1).LINK_DEBUG.TX.PRE_CURSOR;
       reg_data(26)( 3 downto  0)  <= DEFAULT_CM_USP_CTRL_t.CM(1).C2C(1).LINK_DEBUG.TX.PRBS_SEL;
       reg_data(26)( 8 downto  4)  <= DEFAULT_CM_USP_CTRL_t.CM(1).C2C(1).LINK_DEBUG.TX.DIFF_CTRL;
+      reg_data(40)( 0)  <= DEFAULT_CM_USP_CTRL_t.CM(1).C2C(1).CNT.RESET_COUNTERS;
       reg_data(48)(11)  <= DEFAULT_CM_USP_CTRL_t.CM(1).C2C(2).ENABLE_PHY_CTRL;
       reg_data(49)(31 downto  0)  <= DEFAULT_CM_USP_CTRL_t.CM(1).C2C(2).PHY_LANE_STABLE;
       reg_data(50)(23 downto  0)  <= DEFAULT_CM_USP_CTRL_t.CM(1).C2C(2).PHY_READ_TIME;
@@ -819,6 +820,7 @@ begin  -- architecture behavioral
       reg_data(57)(31 downto 27)  <= DEFAULT_CM_USP_CTRL_t.CM(1).C2C(2).LINK_DEBUG.TX.PRE_CURSOR;
       reg_data(58)( 3 downto  0)  <= DEFAULT_CM_USP_CTRL_t.CM(1).C2C(2).LINK_DEBUG.TX.PRBS_SEL;
       reg_data(58)( 8 downto  4)  <= DEFAULT_CM_USP_CTRL_t.CM(1).C2C(2).LINK_DEBUG.TX.DIFF_CTRL;
+      reg_data(72)( 0)  <= DEFAULT_CM_USP_CTRL_t.CM(1).C2C(2).CNT.RESET_COUNTERS;
       reg_data(80)( 7 downto  0)  <= DEFAULT_CM_USP_CTRL_t.CM(1).MONITOR.COUNT_16X_BAUD;
       reg_data(84)( 0)  <= DEFAULT_CM_USP_CTRL_t.CM(1).MONITOR.ERRORS.RESET;
       reg_data(90)(31 downto  0)  <= DEFAULT_CM_USP_CTRL_t.CM(1).MONITOR.SM_TIMEOUT;
@@ -851,6 +853,7 @@ begin  -- architecture behavioral
       reg_data(281)(31 downto 27)  <= DEFAULT_CM_USP_CTRL_t.CM(2).C2C(1).LINK_DEBUG.TX.PRE_CURSOR;
       reg_data(282)( 3 downto  0)  <= DEFAULT_CM_USP_CTRL_t.CM(2).C2C(1).LINK_DEBUG.TX.PRBS_SEL;
       reg_data(282)( 8 downto  4)  <= DEFAULT_CM_USP_CTRL_t.CM(2).C2C(1).LINK_DEBUG.TX.DIFF_CTRL;
+      reg_data(296)( 0)  <= DEFAULT_CM_USP_CTRL_t.CM(2).C2C(1).CNT.RESET_COUNTERS;
       reg_data(304)(11)  <= DEFAULT_CM_USP_CTRL_t.CM(2).C2C(2).ENABLE_PHY_CTRL;
       reg_data(305)(31 downto  0)  <= DEFAULT_CM_USP_CTRL_t.CM(2).C2C(2).PHY_LANE_STABLE;
       reg_data(306)(23 downto  0)  <= DEFAULT_CM_USP_CTRL_t.CM(2).C2C(2).PHY_READ_TIME;
@@ -876,6 +879,7 @@ begin  -- architecture behavioral
       reg_data(313)(31 downto 27)  <= DEFAULT_CM_USP_CTRL_t.CM(2).C2C(2).LINK_DEBUG.TX.PRE_CURSOR;
       reg_data(314)( 3 downto  0)  <= DEFAULT_CM_USP_CTRL_t.CM(2).C2C(2).LINK_DEBUG.TX.PRBS_SEL;
       reg_data(314)( 8 downto  4)  <= DEFAULT_CM_USP_CTRL_t.CM(2).C2C(2).LINK_DEBUG.TX.DIFF_CTRL;
+      reg_data(328)( 0)  <= DEFAULT_CM_USP_CTRL_t.CM(2).C2C(2).CNT.RESET_COUNTERS;
       reg_data(336)( 7 downto  0)  <= DEFAULT_CM_USP_CTRL_t.CM(2).MONITOR.COUNT_16X_BAUD;
       reg_data(340)( 0)  <= DEFAULT_CM_USP_CTRL_t.CM(2).MONITOR.ERRORS.RESET;
       reg_data(346)(31 downto  0)  <= DEFAULT_CM_USP_CTRL_t.CM(2).MONITOR.SM_TIMEOUT;

--- a/tester/test_vhdl_packages.py
+++ b/tester/test_vhdl_packages.py
@@ -23,6 +23,7 @@ class UnitTest(unittest.TestCase):
 
     def assert_compare_dir(self, dir1, dir2):
         """Assert that two directories are identical"""
+        print("Comparing %s to %s" % (dir1, dir2))
         process = subprocess.Popen(["diff", "-r", dir1, dir2],
                                    stdout=subprocess.PIPE)
         out = process.communicate()[0].decode("utf-8")
@@ -42,7 +43,7 @@ class UnitTest(unittest.TestCase):
             self.fail(fail_msg)
         process.terminate()
 
-    def test_parser(self):
+    def test_parser(self, parser_types):
         """Test the parser and XML to VHDL generation"""
 
         for xml in ["CM_USP", "MEM_TEST"]:
@@ -64,20 +65,20 @@ class UnitTest(unittest.TestCase):
                 tests = [{"path": "CParserTest",          "parser": "simple", "template": axi},
                          {"path": "UParserTest",          "parser": "uhal",   "template": axi},
                          {"path": "CParserTest_wishbone", "parser": "simple", "template": wishbone},
-                         {"path": "UParserTest_wishbone", "parser": "simple", "template": wishbone}
-                         ]
+                         {"path": "UParserTest_wishbone", "parser": "simple", "template": wishbone}]
 
                 # Generate the VHDL Outputs
                 for test in tests:
                     for yml2hdl in [True, False]:
+                        if test["parser"] in parser_types:
 
-                        print("Tester:: %s (testxml=%s) with %s parser to %s" %
-                            (xml, test_xml_name, test["parser"], test["path"]))
+                            print("Tester:: %s (testxml=%s) with %s parser to %s" %
+                                (xml, test_xml_name, test["parser"], test["path"]))
 
-                        parse_xml(test_xml=test_xml_name, HDLPath=test["path"],
-                                parser=test["parser"],
-                                regMapTemplate=test["template"],
-                                yml2hdl=yml2hdl)
+                            parse_xml(test_xml=test_xml_name, HDLPath=test["path"],
+                                    parser=test["parser"],
+                                    regMapTemplate=test["template"],
+                                    yml2hdl=yml2hdl)
             finally:
                 os.remove(test_xml_name)
 
@@ -91,4 +92,8 @@ class UnitTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main()
+    test = UnitTest()
+    if (len(sys.argv) == 1):
+        test.test_parser(["uhal", "simple"])
+    else:
+        test.test_parser(sys.argv[1:])


### PR DESCRIPTION
This commit adds a CI job that tests the generated outputs. 

It runs only using the "simple" parser to avoid IPBus dependencies. uHAL parser could be added later as a docker image. 

It checks the simple parser's output against the committed uHAL generated package and will signal an error if they differ, requiring the user to run the uHAL parser locally and commit the output products.